### PR TITLE
Allow IEnumerable types to be used as complex objects

### DIFF
--- a/src/NJsonApiCore/Infrastructure/IDelta.cs
+++ b/src/NJsonApiCore/Infrastructure/IDelta.cs
@@ -17,5 +17,6 @@ namespace NJsonApi.Infrastructure
         Dictionary<string, ICollectionDelta> CollectionDeltas { get; set; }
         IMetaData TopLevelMetaData { get; set; }
         IMetaData ObjectMetaData { get; set; }
+        void Scan();
     }
 }

--- a/src/NJsonApiCore/Infrastructure/IPropertyHandle.cs
+++ b/src/NJsonApiCore/Infrastructure/IPropertyHandle.cs
@@ -14,6 +14,6 @@ namespace NJsonApi.Infrastructure
     {
         Expression<Func<TResource, TProperty>> Expression { get; }
         Func<TResource, TProperty> Getter { get; }
-        Action<TResource, TProperty> Setter { get; }
+        Action<TResource, object> Setter { get; }
     }
 }

--- a/src/NJsonApiCore/Infrastructure/PropertyHandle.cs
+++ b/src/NJsonApiCore/Infrastructure/PropertyHandle.cs
@@ -18,7 +18,7 @@ namespace NJsonApi.Infrastructure
 
         public Expression<Func<TResource, TProperty>> Expression { get; private set; }
         public Func<TResource, TProperty> Getter { get; private set; }
-        public Action<TResource, TProperty> Setter { get; private set; }
+        public Action<TResource, object> Setter { get; private set; }
         public string Name { get; private set; }
 
         public Delegate GetterDelegate { get { return Getter; } }

--- a/src/NJsonApiCore/Serialization/JsonApiTransformer.cs
+++ b/src/NJsonApiCore/Serialization/JsonApiTransformer.cs
@@ -149,6 +149,8 @@ namespace NJsonApi.Serialization
                 delta.ObjectMetaData = updateDocument.Data.MetaData;
             }
 
+            delta.Scan();
+
             return delta;
         }
     }

--- a/src/NJsonApiCore/Utils/ExpressionUtils.cs
+++ b/src/NJsonApiCore/Utils/ExpressionUtils.cs
@@ -111,22 +111,6 @@ namespace NJsonApi.Utils
             Expression exp;
             if (Type.GetTypeCode(pi.PropertyType) == TypeCode.Object)
             {
-                //if (Type.GetTypeCode(tValue) == TypeCode.Object)
-                //{
-
-                //if (tValue.GetInterfaces().Any(x => x == typeof(IEnumerable)))
-                //{
-                //    exp = CreateJArrayTypeSetterExpression(pi, instanceParameter, valueParameter);
-                //}
-                //else
-                //{
-                //    var canConvertToJObject = Expression.Equal(Expression.TypeAs(valueParameter, typeof(JObject)),
-                //        Expression.Constant(null));
-
-                //    exp = Expression.IfThenElse(canConvertToJObject,
-                //        CreateSimpleTypeSetterExpression(pi, instanceParameter, valueParameter),
-                //        CreateJObjectTypeSetterExpression(pi, instanceParameter, valueParameter));
-                //}
                 if (pi.PropertyType.GetInterfaces().Any(x => x == typeof(IEnumerable)))
                 {
                     exp = CreateJArrayTypeSetterExpression(pi, instanceParameter, valueParameter);

--- a/src/NJsonApiCore/Utils/ExpressionUtils.cs
+++ b/src/NJsonApiCore/Utils/ExpressionUtils.cs
@@ -109,9 +109,25 @@ namespace NJsonApi.Utils
             var valueParameter = Expression.Parameter(typeof(object));
 
             Expression exp;
-            if (Type.GetTypeCode(tValue) == TypeCode.Object)
+            if (Type.GetTypeCode(pi.PropertyType) == TypeCode.Object)
             {
-                if (tValue.GetInterfaces().Any(x => x == typeof(IEnumerable)))
+                //if (Type.GetTypeCode(tValue) == TypeCode.Object)
+                //{
+
+                //if (tValue.GetInterfaces().Any(x => x == typeof(IEnumerable)))
+                //{
+                //    exp = CreateJArrayTypeSetterExpression(pi, instanceParameter, valueParameter);
+                //}
+                //else
+                //{
+                //    var canConvertToJObject = Expression.Equal(Expression.TypeAs(valueParameter, typeof(JObject)),
+                //        Expression.Constant(null));
+
+                //    exp = Expression.IfThenElse(canConvertToJObject,
+                //        CreateSimpleTypeSetterExpression(pi, instanceParameter, valueParameter),
+                //        CreateJObjectTypeSetterExpression(pi, instanceParameter, valueParameter));
+                //}
+                if (pi.PropertyType.GetInterfaces().Any(x => x == typeof(IEnumerable)))
                 {
                     exp = CreateJArrayTypeSetterExpression(pi, instanceParameter, valueParameter);
                 }

--- a/src/NJsonApiCore/Utils/ExpressionUtils.cs
+++ b/src/NJsonApiCore/Utils/ExpressionUtils.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -12,10 +14,19 @@ namespace NJsonApi.Utils
         // JObject.ToObject(value) method info
         private static readonly MethodInfo JObjectToObjectMethodInfo =
             typeof(JObject).GetMethods().Single(x => x.Name == "ToObject" && !x.ContainsGenericParameters && x.GetParameters().Length == 1);
+        private static readonly MethodInfo JArrayToObjectMethodInfo =
+            typeof(JArray).GetMethods().Single(x => x.Name == "ToObject" && !x.ContainsGenericParameters && x.GetParameters().Length == 1);
 #else
         // JObject.ToObject(value) method info
         private static readonly MethodInfo JObjectToObjectMethodInfo =
             typeof(JObject).GetMethod("ToObject",
+            BindingFlags.Instance | BindingFlags.Public,
+            null,
+            CallingConventions.HasThis,
+            new[] { typeof(Type) }, null);
+
+        private static readonly MethodInfo JArrayToObjectMethodInfo =
+            typeof(JArray).GetMethod("ToObject",
             BindingFlags.Instance | BindingFlags.Public,
             null,
             CallingConventions.HasThis,
@@ -84,40 +95,50 @@ namespace NJsonApi.Utils
             return (Func<TInstance, TResult>)ToCompiledGetterDelegate(pi, typeof(TInstance), typeof(TResult));
         }
 
+        public static bool IsGenericType(Type type)
+        {
+            return type.GetTypeInfo().IsGenericType;
+        }
+
         public static Delegate ToCompiledSetterDelegate(this PropertyInfo pi, Type tInstance, Type tValue)
         {
             if (!tValue.IsAssignableFrom(pi.PropertyType) && !pi.PropertyType.IsAssignableFrom(tValue))
                 throw new InvalidOperationException($"Unsupported type combination: {tValue} and {pi.GetType()}.");
 
             var instanceParameter = Expression.Parameter(tInstance);
-            var valueParameter = Expression.Parameter(tValue);
+            var valueParameter = Expression.Parameter(typeof(object));
 
+            Expression exp;
             if (Type.GetTypeCode(tValue) == TypeCode.Object)
             {
-                var canConvertToJObject = Expression.Equal(Expression.TypeAs(valueParameter, typeof(JObject)),
-                    Expression.Constant(null));
+                if (tValue.GetInterfaces().Any(x => x == typeof(IEnumerable)))
+                {
+                    exp = CreateJArrayTypeSetterExpression(pi, instanceParameter, valueParameter);
+                }
+                else
+                {
+                    var canConvertToJObject = Expression.Equal(Expression.TypeAs(valueParameter, typeof(JObject)),
+                        Expression.Constant(null));
 
-                var exp = Expression.IfThenElse(canConvertToJObject,
-                    CreateSimpleTypeSetterExpression(pi, instanceParameter, valueParameter),
-                    CreateJObjectTypeSetterExpression(pi, instanceParameter, valueParameter));
-
-                return Expression.Lambda(exp, instanceParameter, valueParameter).Compile();
+                    exp = Expression.IfThenElse(canConvertToJObject,
+                        CreateSimpleTypeSetterExpression(pi, instanceParameter, valueParameter),
+                        CreateJObjectTypeSetterExpression(pi, instanceParameter, valueParameter));
+                }
             }
             else
             {
-                var exp = CreateSimpleTypeSetterExpression(pi, instanceParameter, valueParameter);
-                return Expression.Lambda(exp, instanceParameter, valueParameter).Compile();
+                exp = CreateSimpleTypeSetterExpression(pi, instanceParameter, valueParameter);
             }
+            return Expression.Lambda(exp, instanceParameter, valueParameter).Compile();
         }
 
-        public static Action<TInstance, TValue> ToCompiledSetterAction<TInstance, TValue>(this PropertyInfo pi)
+        public static Action<TInstance, object> ToCompiledSetterAction<TInstance, TValue>(this PropertyInfo pi)
         {
-            return (Action<TInstance, TValue>)ToCompiledSetterDelegate(pi, typeof(TInstance), typeof(TValue));
+            return (Action<TInstance, object>)ToCompiledSetterDelegate(pi, typeof(TInstance), typeof(TValue));
         }
 
         private static Expression CreateSimpleTypeSetterExpression(PropertyInfo pi, ParameterExpression instanceParameter, ParameterExpression valueParameter)
         {
-            
             var mi = pi.GetSetMethod();
             Expression valueExpression = valueParameter;
 
@@ -129,14 +150,27 @@ namespace NJsonApi.Utils
             return body;
         }
 
-        private static Expression CreateJObjectTypeSetterExpression(PropertyInfo pi, ParameterExpression instanceParameter, ParameterExpression valueParameter)
+        private static Expression CreateJObjectTypeSetterExpression(PropertyInfo pi,
+            ParameterExpression instanceParameter, ParameterExpression valueParameter)
         {
-            // Use "(targetType) JObject.ToObject(value)" to get deserialized object
+            return CreateJTokenSetterExpression<JObject>(pi, instanceParameter, valueParameter, JObjectToObjectMethodInfo);
+        }
+
+        private static Expression CreateJArrayTypeSetterExpression(PropertyInfo pi,
+            ParameterExpression instanceParameter, ParameterExpression valueParameter)
+        {
+            return CreateJTokenSetterExpression<JArray>(pi, instanceParameter, valueParameter, JArrayToObjectMethodInfo);
+        }
+
+        private static Expression CreateJTokenSetterExpression<TJTokenType>(PropertyInfo pi,
+            ParameterExpression instanceParameter, ParameterExpression valueParameter, MethodInfo method) where TJTokenType : JToken
+        {
+            // Use "(targetType) {JObject/JArray}.ToObject(value)" to get deserialized object
             var mi = pi.GetSetMethod();
             var typeConstant = Expression.Constant(pi.PropertyType);
 
-            var convertToJObjectExpression = Expression.Convert(valueParameter, typeof(JObject));
-            var toObjectCall = Expression.Call(convertToJObjectExpression, JObjectToObjectMethodInfo, typeConstant);
+            var convertToJObjectExpression = Expression.Convert(valueParameter, typeof(TJTokenType));
+            var toObjectCall = Expression.Call(convertToJObjectExpression, method, typeConstant);
             var convertToTargetTypeExpression = Expression.Convert(toObjectCall, pi.PropertyType);
             var body = Expression.Call(instanceParameter, mi, convertToTargetTypeExpression);
 

--- a/test/NJsonApiCore.Test/Builders/TestModelConfigurationBuilder.cs
+++ b/test/NJsonApiCore.Test/Builders/TestModelConfigurationBuilder.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using NJsonApi;
 using NJsonApi.Test.TestModel;
 using NJsonApi.Test.TestControllers;
+using NJsonApiCore.Test.TestModel;
 
 namespace NJsonApi.Test.Builders
 {
@@ -31,6 +32,11 @@ namespace NJsonApi.Test.Builders
                     .Resource<Product, ProductsController>()
                     .WithAllSimpleProperties()
                     .WithSimpleProperty(x => x.Dimensions);
+
+                builder
+                    .Resource<Widget, WidgetsController>()
+                    .WithAllSimpleProperties()
+                    .WithSimpleProperty(x => x.Parts);
 
                 return builder;
             }

--- a/test/NJsonApiCore.Test/Infrastructure/DeltaTest.cs
+++ b/test/NJsonApiCore.Test/Infrastructure/DeltaTest.cs
@@ -14,14 +14,16 @@ namespace NJsonApi.Test.Infrastructure
             //Arange
             var author = new Author();
             var classUnderTest = new Delta<Author>();
-
-            classUnderTest.FilterOut(t => t.Name);
+            
             classUnderTest.ObjectPropertyValues =
                 new Dictionary<string, object>()
                 {
                     {"Id", 1},
                     {"DateTimeCreated", new DateTime(2016,1,1)}
                 };
+            classUnderTest.Scan();
+            classUnderTest.FilterOut(t => t.Name);
+
             //Act
             classUnderTest.ApplySimpleProperties(author);
 

--- a/test/NJsonApiCore.Test/Infrastructure/DeltaTest.cs
+++ b/test/NJsonApiCore.Test/Infrastructure/DeltaTest.cs
@@ -11,7 +11,7 @@ namespace NJsonApi.Test.Infrastructure
         [Fact]
         public void GIVEN_IncompleteProperties_WHEN_DeltaApply_THEN_OnlyThoseSpecifiedApplied()
         {
-            //Arange
+            //Arrange
             var author = new Author();
             var classUnderTest = new Delta<Author>();
             
@@ -39,6 +39,7 @@ namespace NJsonApi.Test.Infrastructure
             //Arrange
             var simpleObject = new Author();
             var objectUnderTest = new Delta<Author>();
+            objectUnderTest.Scan();
 
             //Act
             objectUnderTest.ApplySimpleProperties(simpleObject);
@@ -47,6 +48,48 @@ namespace NJsonApi.Test.Infrastructure
             Assert.Equal(simpleObject.Id, 0);
             Assert.Null(simpleObject.Name);
             Assert.Equal(simpleObject.DateTimeCreated, new DateTime());
+        }
+
+        [Fact]
+        public void GIVEN_ScanNotCalled_WHEN_DeltaFilterOut_THEN_ExceptionThrown()
+        {
+            //Arrange
+            var classUnderTest = new Delta<Author>();
+
+            classUnderTest.ObjectPropertyValues =
+                new Dictionary<string, object>()
+                {
+                    {"Id", 1},
+                    {"DateTimeCreated", new DateTime(2016,1,1)}
+                };
+
+            //Act/Assert
+            var ex = Assert.Throws<Exception>(()=> classUnderTest.FilterOut(t => t.Name));
+            Assert.Equal("Scan must be called before this method", ex.Message);
+        }
+
+        [Fact]
+        public void GIVEN_ScanNotCalled_WHEN_DeltaApplySimpleProperties_THEN_ExceptionThrown()
+        {
+            //Arrange
+            var author = new Author();
+            var classUnderTest = new Delta<Author>();
+
+            //Act/Assert
+            var ex = Assert.Throws<Exception>(() => classUnderTest.ApplySimpleProperties(author));
+            Assert.Equal("Scan must be called before this method", ex.Message);
+        }
+
+        [Fact]
+        public void GIVEN_ScanNotCalled_WHEN_DeltaApplyCollections_THEN_ExceptionThrown()
+        {
+            //Arrange
+            var author = new Author();
+            var classUnderTest = new Delta<Author>();
+
+            //Act/Assert
+            var ex = Assert.Throws<Exception>(() => classUnderTest.ApplyCollections(author));
+            Assert.Equal("Scan must be called before this method", ex.Message);
         }
     }
 }

--- a/test/NJsonApiCore.Test/Serialization/JsonApiTransformerTest/TestSerialization.cs
+++ b/test/NJsonApiCore.Test/Serialization/JsonApiTransformerTest/TestSerialization.cs
@@ -26,7 +26,8 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
 
             // Assert
             Assert.DoesNotContain(json, "Data");
-            Assert.True(json.Contains("\"complexAttribute\":{\"Label\":\"This is complex attribute class\",\"InnerComplexAttribute\":{\"AnotherLabel\":\"This is inner complex attribute class\"}}}"));
+            Assert.True(json.Contains("\"complexAttribute\":{\"Label\":\"This is complex attribute class\",\"InnerComplexAttribute\":{\"AnotherLabel\":\"This is inner complex attribute class\"}}"));
+            Assert.True(json.Contains("\"listAttribute\":[{\"Label\":\"Complex 1\",\"InnerComplexAttribute\":{\"AnotherLabel\":\"This is inner complex attribute class\"}},{\"Label\":\"Complex 2\",\"InnerComplexAttribute\":{\"AnotherLabel\":\"This is inner complex attribute class\"}}]"));
         }
 
         private static SampleClass CreateObjectToTransform()
@@ -42,6 +43,20 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
                 InnerComplexAttribute = innerComplexAttribute
             };
 
+            var listAttribute = new List<ComplexAttributeClass>()
+            {
+                new ComplexAttributeClass()
+                {
+                    Label = "Complex 1",
+                    InnerComplexAttribute = innerComplexAttribute
+                },
+                new ComplexAttributeClass()
+                {
+                    Label = "Complex 2",
+                    InnerComplexAttribute = innerComplexAttribute
+                }
+            };
+
             var deepest = new DeeplyNestedClass()
             {
                 Id = 100,
@@ -55,6 +70,7 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
                 DateTime = DateTime.UtcNow,
                 NotMappedValue = "Should be not mapped",
                 ComplexAttribute = complexAttribute,
+                ListAttribute = listAttribute,
                 NestedClass = new List<NestedClass>()
                 {
                     new NestedClass()
@@ -91,6 +107,7 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
             sampleClassMapping.AddPropertyGetter("someValue", c => c.SomeValue);
             sampleClassMapping.AddPropertyGetter("date", c => c.DateTime);
             sampleClassMapping.AddPropertyGetter("complexAttribute", c => c.ComplexAttribute);
+            sampleClassMapping.AddPropertyGetter("listAttribute", c => c.ListAttribute);
 
             var nestedClassMapping = new ResourceMapping<NestedClass, DummyController>(c => c.Id);
             nestedClassMapping.ResourceType = "nestedClasses";
@@ -132,6 +149,7 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
             public DateTime DateTime { get; set; }
             public string NotMappedValue { get; set; }
             public ComplexAttributeClass ComplexAttribute { get; set; }
+            public List<ComplexAttributeClass> ListAttribute { get; set; }
             public IEnumerable<NestedClass> NestedClass { get; set; }
         }
 

--- a/test/NJsonApiCore.Test/Serialization/JsonApiTransformerTest/TestTransformBack.cs
+++ b/test/NJsonApiCore.Test/Serialization/JsonApiTransformerTest/TestTransformBack.cs
@@ -5,6 +5,10 @@ using NJsonApi.Test.Builders;
 using NJsonApi.Test.TestModel;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NJsonApiCore.Test.TestModel;
 using Xunit;
 
 namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
@@ -98,8 +102,47 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
 
             // Assert
             Assert.True(resultDelta.ObjectPropertyValues.ContainsKey("Name"));
+            Console.WriteLine(resultDelta.ObjectPropertyValues["Dimensions"]);
             Assert.True(resultDelta.ObjectPropertyValues.ContainsKey("Dimensions"));
-            Assert.Equal(resultDelta.ObjectPropertyValues["Dimensions"], dimensions);
+            Assert.Equal(dimensions, resultDelta.ObjectPropertyValues["Dimensions"]);
+        }
+
+        [Fact]
+        public void Transform_UpdateDocument_To_Delta_Containing_ListAttribute()
+        {
+            //DS: TODO - should widgetParts be provided as a JArray?
+            // Arrange
+            var widgetParts = new List<WidgetPart>()
+            {
+                new WidgetPart() { PartNumber = "WIDGET-001" },
+                new WidgetPart() { PartNumber = "WIDGET-002" }
+            };
+            var jArrayWidgetParts = JArray.FromObject(widgetParts);
+            var updateDocument = new UpdateDocument
+            {
+                Data = new SingleResource()
+                {
+                    Id = "123",
+                    Type = "widget",
+                    Attributes = new Dictionary<string, object>()
+                    {
+                        {"name", "A widget" },
+                        {"parts", widgetParts }
+                    }
+                }
+            };
+
+            var config = TestModelConfigurationBuilder.BuilderForEverything.Build();
+            var context = new Context(new Uri("http://fakehost:1234", UriKind.Absolute));
+            var transformer = new JsonApiTransformerBuilder().With(config).Build();
+
+            // Act
+            var resultDelta = transformer.TransformBack(updateDocument, typeof(Widget), context);
+
+            // Assert
+            Assert.True(resultDelta.ObjectPropertyValues.ContainsKey("Name"));
+            Assert.True(resultDelta.ObjectPropertyValues.ContainsKey("Parts"));
+            Assert.Equal(resultDelta.ObjectPropertyValues["Parts"], widgetParts);
         }
 
         [Fact]

--- a/test/NJsonApiCore.Test/Serialization/JsonApiTransformerTest/TestTransformBack.cs
+++ b/test/NJsonApiCore.Test/Serialization/JsonApiTransformerTest/TestTransformBack.cs
@@ -102,7 +102,6 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
 
             // Assert
             Assert.True(resultDelta.ObjectPropertyValues.ContainsKey("Name"));
-            Console.WriteLine(resultDelta.ObjectPropertyValues["Dimensions"]);
             Assert.True(resultDelta.ObjectPropertyValues.ContainsKey("Dimensions"));
             Assert.Equal(dimensions, resultDelta.ObjectPropertyValues["Dimensions"]);
         }
@@ -117,7 +116,6 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
                 new WidgetPart() { PartNumber = "WIDGET-001" },
                 new WidgetPart() { PartNumber = "WIDGET-002" }
             };
-            var jArrayWidgetParts = JArray.FromObject(widgetParts);
             var updateDocument = new UpdateDocument
             {
                 Data = new SingleResource()

--- a/test/NJsonApiCore.Test/TestControllers/WidgetsController.cs
+++ b/test/NJsonApiCore.Test/TestControllers/WidgetsController.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using NJsonApiCore.Test.TestModel;
+
+namespace NJsonApi.Test.TestControllers
+{
+    internal class WidgetsController
+    {
+        [HttpGet]
+        public Widget Get(int id)
+        {
+            return new Widget();
+        }
+    }
+}

--- a/test/NJsonApiCore.Test/TestModel/Widget.cs
+++ b/test/NJsonApiCore.Test/TestModel/Widget.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace NJsonApiCore.Test.TestModel
+{
+    internal class Widget
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public IList<WidgetPart> Parts { get; set; }
+    }
+}

--- a/test/NJsonApiCore.Test/TestModel/WidgetPart.cs
+++ b/test/NJsonApiCore.Test/TestModel/WidgetPart.cs
@@ -1,0 +1,7 @@
+﻿namespace NJsonApiCore.Test.TestModel
+{
+    internal class WidgetPart
+    {
+        public string PartNumber { get; set; }
+    }
+}

--- a/test/NJsonApiCore.Test/Utils/ExpressionUtilsTest.cs
+++ b/test/NJsonApiCore.Test/Utils/ExpressionUtilsTest.cs
@@ -1,5 +1,7 @@
 ﻿using NJsonApi.Utils;
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using Newtonsoft.Json.Linq;
@@ -90,6 +92,25 @@ namespace NJsonApi.Common.Test.Utils
         }
 
         [Fact]
+        public void ToCompiledSetterAction_GivenListType_ReturnsWorkingDelegate()
+        {
+            // Arrange
+            var complex = new ListClass();
+            var listType = new List<ComplexClass>() {new ComplexClass() {Foo = new Foo() {Bar ="bar"}}};
+            var obj = JArray.FromObject(listType);
+
+            var action = typeof(ListClass).GetProperty(nameof(complex.ListType)).ToCompiledSetterAction<ListClass, List<ComplexClass>>();
+
+            // Act
+            action(complex, obj);
+
+            // Assert
+            Assert.NotNull(complex.ListType);
+            Assert.Equal(complex.ListType.Count, 1);
+            Assert.Equal("bar", complex.ListType[0].Foo.Bar);
+        }
+
+        [Fact]
         public void ToCompiledSetterAction_GivenBaseTypeAndInvalidObject_ThrowsInvalidCastException()
         {
             // Arrange
@@ -154,6 +175,11 @@ namespace NJsonApi.Common.Test.Utils
                 get;
                 set;
             }
+        }
+
+        private class ListClass
+        {
+            public IList<ComplexClass> ListType { get; set; }
         }
     }
 }


### PR DESCRIPTION
Add to the complex object support by allowing `IEnumerable` types to be used as complex objects that can be serialized/deserialized as inline attributes.

Setter delegates are created based on the "simple" model properties (either because they are "simple" types, or because they have been added as simple properties using the fluent builder interface).  When a resource is `POST`ed, the JSON is deserialized to a `JToken`; for non-list types this `JToken` should be a `JObject`, and for `IEnumerable` types it should be a `JArray`.  An appropriate delegate is produced to handle each case.

In order to support this change the `Delta<T>` class now determines whether an attribute in the JSON is deserialized as a simple property or relationship by comparing the attribute name with those in the mapping configurations; if the attribute has a relationship mapping, then it will be treated as a relationship, and conversely if it has a simple property mapping, then it will be treated as an inline attribute.  This means that the mapping configuration must be applied to `Delta<T>` before `FilterOut()`, `ApplySimpleProperties()` or `ApplyCollections()`  are called.  To this end, a `Scan()` method has been added to `Delta<T>` which must be called after the mapping configuration properties are populated, and before any of the aforementioned operations are executed.