### PR TITLE
Map top level meta data from ITopLevelDocument rather than IObjectMetaData

### DIFF
--- a/src/NJsonApiCore/Serialization/JsonApiTransformer.cs
+++ b/src/NJsonApiCore/Serialization/JsonApiTransformer.cs
@@ -54,7 +54,7 @@ namespace NJsonApi.Serialization
 
             var result = new CompoundDocument
             {
-                Meta = transformationHelper.GetMetadata(objectGraph)
+                Meta = transformationHelper.GetTopLevelMetadata(objectGraph)
             };
 
             var resource = transformationHelper.UnwrapResourceObject(objectGraph);

--- a/src/NJsonApiCore/Serialization/TransformationHelper.cs
+++ b/src/NJsonApiCore/Serialization/TransformationHelper.cs
@@ -164,11 +164,11 @@ namespace NJsonApi.Serialization
             return objectGraph;
         }
 
-        public IMetaData GetMetadata(object objectGraph)
+        public IMetaData GetTopLevelMetadata(object objectGraph)
         {
-            if (objectGraph is IObjectMetaDataContainer)
+            if (objectGraph is ITopLevelDocument)
             {
-                var metaDataContainer = objectGraph as IObjectMetaDataContainer;
+                var metaDataContainer = objectGraph as ITopLevelDocument;
                 return metaDataContainer.GetMetaData();
             }
             return null;

--- a/test/NJsonApiCore.Test/Serialization/JsonApiTransformerTest/TestMetaData.cs
+++ b/test/NJsonApiCore.Test/Serialization/JsonApiTransformerTest/TestMetaData.cs
@@ -48,6 +48,7 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
             var transformedObject = result.Data as SingleResource;
             Assert.Equal("value1", transformedObject.MetaData["meta1"]);
             Assert.Equal("value2", transformedObject.MetaData["meta2"]);
+            Assert.Null(result.Meta);
         }
 
         [Fact]


### PR DESCRIPTION
The transformer was serialising object meta data at both the top level and object level.  This PR changes that behavior such that the top level `CompoundDocument` maps its meta data property from `ITopLevelDocument` objects.